### PR TITLE
ENG-4264 Update paths in the CSS file in order to avoid 404 errors on widget load

### DIFF
--- a/prepareBundle.sh
+++ b/prepareBundle.sh
@@ -116,16 +116,28 @@ function updateFTLTemplate() {
             injectResource "$resource" "$ftlName"
         done
 
-        # For every CSS file add a script reference in the widget FTL
+        # For every CSS file add a script reference in the widget FTL and update the static media folder url
         for csspath in "$dir"/resources/static/css/*.css;
         do
 
           # This moves the referenced file to the top level bundle/resources/static dir for correct processing when loaded
+          # and update the static media folder url to the bundle static media in order to avoid some 404 errors on load
           cssfile=$(basename "$csspath")
+
+          local originalStaticMedia="url(/static/media/"
+          local staticMediaBundle="src: url(/$bundleCode/static/media/"
+          echo ""
+          echo "> Updating micro-frontend static media path in $cssfile"
+          echo "> original static media path: $originalStaticMedia"
+          echo "> bundle static media path: $staticMediaBundle"
+          echo "> css file path: $dir/resources/static/css/$cssfile"
+          sedReplace "s|$originalStaticMedia|$staticMediaBundle|g" "$dir/resources/static/css/$cssfile"
+          echo "CSS static media folder updated"
 
           cp "$dir/resources/static/css/$cssfile" bundle/resources/static/css/
           resource="<link href=\"<@wp.resourceURL />${bundleCode}/static/css/${cssfile}\" rel=\"stylesheet\">"
           injectResource "$resource" "$ftlName"
+
         done
     done
 

--- a/prepareBundle.sh
+++ b/prepareBundle.sh
@@ -125,7 +125,7 @@ function updateFTLTemplate() {
           cssfile=$(basename "$csspath")
 
           local originalStaticMedia="url(/static/media/"
-          local staticMediaBundle="src: url(/$bundleCode/static/media/"
+          local staticMediaBundle="url(/$bundleCode/static/media/"
           echo ""
           echo "> Updating micro-frontend static media path in $cssfile"
           echo "> original static media path: $originalStaticMedia"


### PR DESCRIPTION
Update the static media folder url to the bundle static media path in the bundle resources/static/css files in order to avoid some 404 errors on load